### PR TITLE
Implicit multiplication

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,15 +29,15 @@ java -jar ./build/kalculator.jar [equation]
 | `--debug` | `-d`      | Run in debug mode |
 
 ## Syntax
-| Operation       | Syntax    |
-|-----------------|-----------|
-| Addition        | `n + n`   |
-| Subtraction     | `n - n`   |
-| Division        | `n / n`   |
-| Multiplication  | `n * n`   |
-| Exponentiation  | `n^n`     |
-| Ordering        | `( ... )` |
-| Variable        | `x`       |
+| Operation       | Syntax                                      |
+|-----------------|---------------------------------------------|
+| Addition        | `n + n`                                     |
+| Subtraction     | `n - n`                                     |
+| Division        | `n / n`                                     |
+| Multiplication  | `n * n`, `(n)(n)`, `n(n)`/`(n)n`, `nx`/`xn` |
+| Exponentiation  | `n^n`                                       |
+| Ordering        | `( ... )`                                   |
+| Variable        | `x`                                         |
 
 ### Variables
 There is a single variable `x`. It is only available in the REPL after the first equation is resolved.


### PR DESCRIPTION
Previously `(<equation>)(<equation>)` would produce two separate equations and results. Instead of throwing an error I implemented this to be another way to write multiplication.

**New valid equations:**
```
(2)(3)
= 6

4(5)
= 20

(6)7
= 42

2^(2)(2)
= 16

2x
= 32

x2
= 64
```

**A weird case:**
```
6/2(1+2)
= 1
```

Some calculators (Google, Spotlight Search, etc) will evaluate this to 9, treating the equation as `(6/2)*(1+2)`. I went with an approach that is fairly common and intuitive. Implicit multiplication is higher in order of operations. So the equation is read as `6/(2*(1+2))`. Why? Well... it was easier. ¯\_(ツ)_/¯ 