### PR TITLE
Native functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,25 @@ java -jar ./build/kalculator.jar [equation]
 ### Variables
 There is a single variable `x`. It is only available in the REPL after the first equation is resolved.
 At which point, `x` is automatically set to the result of the previous equation.
+
+### Grammar
+```
+equation    -> ( expression )*
+
+expression  -> term
+
+term        -> factor ( ( '-' | '+' ) factor | factor )*
+
+factor      -> unary ( ( '/' | '*' ) unary | unary )*
+
+unary       -> ( '-' ) unary
+            | primary
+            
+call        -> IDENTIFIER ( '{' arguments? '}' )*
+
+arguments   -> expression ( ',' expression )*
+
+primary     -> NUMBER
+            -> IDENTIFIER
+            | '(' expression ')'
+```

--- a/src/main/kotlin/kalculator/AstPrinter.kt
+++ b/src/main/kotlin/kalculator/AstPrinter.kt
@@ -25,4 +25,9 @@ class AstPrinter: Expr.Visitor<String> {
     override fun visitVariableExpr(expr: Expr.Variable): String {
         return "(var ${expr.name.lexeme})"
     }
+
+    override fun visitCallExpr(expr: Expr.Call): String {
+        val arguments = expr.arguments.map {it.accept(this)}
+        return "(fn ${(expr.callee as Expr.Variable).name.lexeme}: ${arguments.joinToString(", ")})"
+    }
 }

--- a/src/main/kotlin/kalculator/Environment.kt
+++ b/src/main/kotlin/kalculator/Environment.kt
@@ -12,6 +12,10 @@ class Environment {
     }
 
     fun assign(name: Token, value: Any) {
-        values.put(name.lexeme, value)
+        assign(name.lexeme, value)
+    }
+
+    fun assign(name: String, value: Any) {
+        values.put(name, value)
     }
 }

--- a/src/main/kotlin/kalculator/Expr.kt
+++ b/src/main/kotlin/kalculator/Expr.kt
@@ -8,6 +8,7 @@ abstract class Expr {
         fun visitUnaryExpr(expr: Unary): T
         fun visitGroupingExpr(expr: Grouping): T
         fun visitVariableExpr(expr: Variable): T
+        fun visitCallExpr(expr: Call): T
     }
 
     abstract fun <T>accept(visitor: Visitor<T>): T
@@ -39,6 +40,12 @@ abstract class Expr {
     data class Variable(val name: Token): Expr() {
         override fun <T>accept(visitor: Visitor<T>): T {
             return visitor.visitVariableExpr(this)
+        }
+    }
+
+    data class Call(val callee: Expr, val arguments: List<Expr>): Expr() {
+        override fun <T>accept(visitor: Visitor<T>): T {
+            return visitor.visitCallExpr(this)
         }
     }
 }

--- a/src/main/kotlin/kalculator/Interpreter.kt
+++ b/src/main/kotlin/kalculator/Interpreter.kt
@@ -1,11 +1,16 @@
 package kalculator
 
 import kalculator.TokenType.*
-import kotlin.math.exp
+import kalculator.builtin.Function
+import kalculator.builtin.Root
 import kotlin.math.pow
 
 class Interpreter: Expr.Visitor<Any?> {
     val environment = Environment()
+
+    constructor() {
+        environment.assign("root", Root())
+    }
 
     fun interpret(expressions: List<Expr>) {
         for (expression in expressions) {
@@ -54,5 +59,20 @@ class Interpreter: Expr.Visitor<Any?> {
 
     override fun visitVariableExpr(expr: Expr.Variable): Any? {
         return environment.get(expr.name)
+    }
+
+    override fun visitCallExpr(expr: Expr.Call): Any? {
+        val callee: Any? = evaluate(expr.callee)
+        val arguments: MutableList<Any?> = ArrayList()
+        for (argument in expr.arguments) {
+            arguments.add(evaluate(argument))
+        }
+        if (callee !is Function)
+            throw InterpretError("Can only call functions")
+
+        if (arguments.size != callee.arity())
+            throw InterpretError("Expected ${callee.arity()} arguments but received ${arguments.size}.")
+
+        return callee.call(arguments)
     }
 }

--- a/src/main/kotlin/kalculator/Parser.kt
+++ b/src/main/kotlin/kalculator/Parser.kt
@@ -50,7 +50,25 @@ class Parser (tokens: List<Token>) {
             return Expr.Unary(operator, right)
         }
 
-        return primary()
+        return call()
+    }
+
+    private fun call(): Expr {
+        val expr: Expr = primary()
+        if (match(LEFT_BRACE)) {
+            val arguments: MutableList<Expr> = ArrayList()
+            if (!check(RIGHT_BRACE)) {
+                do {
+                    arguments.add(expression())
+                } while (match(COMMA))
+            }
+
+            consume(RIGHT_BRACE, "Expected '}' after argument list")
+
+            return Expr.Call(callee=expr, arguments=arguments)
+        }
+
+        return expr
     }
 
     private fun primary(): Expr {

--- a/src/main/kotlin/kalculator/Scanner.kt
+++ b/src/main/kotlin/kalculator/Scanner.kt
@@ -16,7 +16,10 @@ class Scanner(source: String) {
             '/' to SLASH,
             '*' to STAR,
             '(' to LEFT_PAREN,
-            ')' to RIGHT_PAREN
+            ')' to RIGHT_PAREN,
+            '{' to LEFT_BRACE,
+            '}' to RIGHT_BRACE,
+            ',' to COMMA
         )
     }
 

--- a/src/main/kotlin/kalculator/TokenType.kt
+++ b/src/main/kotlin/kalculator/TokenType.kt
@@ -9,5 +9,8 @@ enum class TokenType {
     STAR,
     LEFT_PAREN,
     RIGHT_PAREN,
-    IDENTIFIER
+    LEFT_BRACE,
+    RIGHT_BRACE,
+    IDENTIFIER,
+    COMMA
 }

--- a/src/main/kotlin/kalculator/builtin/Function.kt
+++ b/src/main/kotlin/kalculator/builtin/Function.kt
@@ -1,0 +1,9 @@
+package kalculator.builtin
+
+abstract class Function(val name: String) {
+    abstract fun arity(): Number
+    abstract fun call(arguments: List<Any?>): Any?
+    override fun toString(): String {
+        return "<native fn: '${name}'>"
+    }
+}

--- a/src/main/kotlin/kalculator/builtin/RootFn.kt
+++ b/src/main/kotlin/kalculator/builtin/RootFn.kt
@@ -1,0 +1,13 @@
+package kalculator.builtin
+
+import kotlin.math.pow
+
+class Root: Function("root") {
+    override fun arity(): Number {
+        return 2
+    }
+
+    override fun call(arguments: List<Any?>): Any {
+        return (arguments[0] as Double).pow(1/arguments[1] as Double)
+    }
+}


### PR DESCRIPTION
Added support for native functions.

Functions are defined as

```
call       -> IDENTIFIER '{' arguments '}' 
arguments  -> expression ( ',' expression )*                  
```

Currently the only one is `root{r, i} ` which takes in two arguments `radicand` (r) and `index` (i) to perform a root equation ($\sqrt[i]{r}$).